### PR TITLE
skip region monitoring if map object is null

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -699,13 +699,13 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   // Timer Implementation
 
   public void startMonitoringRegion() {
-    if (isMonitoringRegion) return;
+    if (map == null || isMonitoringRegion) return;
     timerHandler.postDelayed(timerRunnable, 100);
     isMonitoringRegion = true;
   }
 
   public void stopMonitoringRegion() {
-    if (!isMonitoringRegion) return;
+    if (map == null || !isMonitoringRegion) return;
     timerHandler.removeCallbacks(timerRunnable);
     isMonitoringRegion = false;
   }


### PR DESCRIPTION
This happen if google play services version is lower than required